### PR TITLE
Mask dots in grep regexp

### DIFF
--- a/build-rpm.sh
+++ b/build-rpm.sh
@@ -266,7 +266,7 @@ fi
 
 sudo touch -d "23 hours ago" $config_dir/default.cfg
 
-spec_name=`ls -1 $build_package | grep '.spec$'`
+spec_name=`ls -1 $build_package | grep '\.spec$'`
 echo '--> Build src.rpm'
 try_rebuild=true
 retry=0
@@ -384,7 +384,7 @@ find_spec() {
 [ "$rerun_tests" = 'true' ] && return 0
 
 # Check count of *.spec files (should be one)
-x=$(ls -1 | grep -c '.spec$' | sed 's/^ *//' | sed 's/ *$//')
+x=$(ls -1 | grep -c '\.spec$' | sed 's/^ *//' | sed 's/ *$//')
 if [ "$x" -eq "0" ] ; then
     echo '--> There are no spec files in repository.'
     exit 1


### PR DESCRIPTION
In grep regexp dot symbol "." means ANY SYMBOL and should be masked by "\".
Without masking it produces false error "There are more than one spec file in repository" on such set of files for example:

macros.openstack-common
macros.openstack-fedora
macros.openstack-rdo
macros.openstack-singlespec
macros.openstack-suse
openstack-macros.spec